### PR TITLE
fix: auth page 'useSearchParams'

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -7,23 +7,27 @@ const AuthPage = () => {
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    // Extract query parameters
-    const type = searchParams.get("type");
-    const phoneNumber = searchParams.get("phoneNumber");
-    const password = searchParams.get("password");
-    const userName = searchParams.get("userName");
-    const contactInfo = searchParams.get("contactInfo");
-    const whatsApp = searchParams.get("whatsApp");
+    if (!searchParams) return;
 
-    // Log the data to the console
-    console.log("Auth Type:", type);
-    console.log("Phone Number:", phoneNumber);
-    console.log("Password:", password);
+    // Extract query parameters with safe defaults
+    const type = searchParams.get("type") || "unknown";
+    const phoneNumber = searchParams.get("phoneNumber") || "N/A";
+    const password = searchParams.get("password") || "N/A";
+    const userName = searchParams.get("userName") || "N/A";
+    const contactInfo = searchParams.get("contactInfo") || "N/A";
+    const whatsApp = searchParams.get("whatsApp") || "N/A";
 
-    if (type === "signup") {
-      console.log("User Name:", userName);
-      console.log("Contact Info:", contactInfo);
-      console.log("WhatsApp:", whatsApp);
+    // Log query parameters conditionally
+    if (process.env.NODE_ENV === "development") {
+      console.log("Auth Type:", type);
+      console.log("Phone Number:", phoneNumber);
+      console.log("Password:", password);
+
+      if (type === "signup") {
+        console.log("User Name:", userName);
+        console.log("Contact Info:", contactInfo);
+        console.log("WhatsApp:", whatsApp);
+      }
     }
   }, [searchParams]);
 


### PR DESCRIPTION
**Use of useSearchParams**
The hook is only available on the client side, which is fine since you're using at the top. However, Next.js might still encounter issues during prerendering if the runtime environment isn't fully aligned. Let's ensure everything is correctly `handled.useSearchParams` `"use client"`

**Handle Absence of Query Parameters**
If the object is or if some parameters are missing, it might cause unexpected behavior. Add a check to avoid potential runtime errors. `searchParams null`